### PR TITLE
manifest: track xiaomi hardware

### DIFF
--- a/snippets/voltage.xml
+++ b/snippets/voltage.xml
@@ -58,6 +58,7 @@
   <project path="hardware/libhardware" name="hardware_libhardware" remote="voltage" />
   <project path="hardware/interfaces" name="hardware_interfaces" remote="voltage" />
   <project path="hardware/lineage/interfaces" name="hardware_voltage_interfaces" remote="voltage" />
+  <project path="hardware/xiaomi" name="hardware_xiaomi" remote="voltage-main" />
   <project path="hardware/qcom-caf/msm8996/audio" name="hardware_qcom_audio" revision="14-msm8996" remote="voltage" />
   <project path="hardware/qcom-caf/msm8996/display" name="hardware_qcom_display" revision="14-msm8996" remote="voltage" />
   <project path="hardware/qcom-caf/msm8996/media" name="hardware_qcom_media" revision="14-msm8996" remote="voltage" />


### PR DESCRIPTION
this repo is currently not being tracked in the VoltageOS-staging 14 manifest